### PR TITLE
 Some fixes to prep for rails5

### DIFF
--- a/groupify.gemspec
+++ b/groupify.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.3"
 
   gem.add_development_dependency "mongoid", ">= 3.1"
-  gem.add_development_dependency "activerecord", ">= 3.2", "< 5"
+  gem.add_development_dependency "activerecord", ">= 3.2", "< 5.1"
 
   gem.add_development_dependency "rspec", ">= 3"
 

--- a/lib/groupify/adapter/active_record/group.rb
+++ b/lib/groupify/adapter/active_record/group.rb
@@ -32,14 +32,14 @@ module Groupify
         members = args.flatten
         return unless members.present?
 
-        clear_association_cache
+        self.send(:clear_association_cache)
 
         members.each do |member|
           member.groups << self unless member.groups.include?(self)
           if membership_type
             member.group_memberships.where(group_id: id, group_type: self.class.model_name.to_s, membership_type: membership_type).first_or_create!
           end
-          member.clear_association_cache
+          member.send(:clear_association_cache)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,10 @@ require 'bundler/setup'
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
-]
+])
 SimpleCov.start
 
 require 'active_support'


### PR DESCRIPTION
```
* Change the clear_association_cache calls to .send()
* Update gemspec to allow < rails5.1
* Fix a depreciated array init on tests
```

Basically I just converted the direct call to a send which is what most of the other gems running into this issue are doing.
